### PR TITLE
Don't sort the priority queue on Append

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -5,7 +5,6 @@ package queue
 
 import (
 	"container/heap"
-	"sort"
 	"sync"
 	"time"
 )
@@ -79,7 +78,6 @@ func (pq *priorityQueue) Push(x interface{}) {
 	element.timestamp = time.Now()
 	element.index = n
 	*pq = append(*pq, element)
-	sort.Sort(*pq)
 }
 
 // Pop removes the next element from the queue in priority order.

--- a/queue_test.go
+++ b/queue_test.go
@@ -128,3 +128,45 @@ func TestLen(t *testing.T) {
 		t.Errorf("A Queue with elements returned a length of %d instead of one", l)
 	}
 }
+
+func BenchmarkAppend(b *testing.B) {
+	q := NewQueue()
+
+	for i := 0; i < b.N; i++ {
+		q.Append("testing")
+	}
+	if e, _ := q.Next(); e != "testing" {
+		b.Errorf("The element was appended as %s instead of 'testing'", e.(string))
+	}
+	if want, have := b.N-1, q.Len(); want != have {
+		b.Errorf("Expected %d elements left on the queue, got %d", want, have)
+	}
+}
+
+func BenchmarkAppendPriority(b *testing.B) {
+	q := NewQueue()
+
+	values := []struct {
+		token    string
+		priority int
+	}{
+		{"valueLow", PriorityLow},
+		{"valueNormal", PriorityNormal},
+		{"valueHigh", PriorityHigh},
+		{"valueCritical", PriorityCritical},
+	}
+	topIdx := -1
+	for i := 0; i < b.N; i++ {
+		idx := i % len(values)
+		q.AppendPriority(values[idx].token, values[idx].priority)
+		if topIdx < idx {
+			topIdx = idx
+		}
+	}
+	if e, _ := q.Next(); topIdx > -1 && e != values[topIdx].token {
+		b.Errorf("The element was appended as %s instead of %s", e.(string), values[topIdx].token)
+	}
+	if want, have := b.N-1, q.Len(); want != have {
+		b.Errorf("Expected %d elements left on the queue, got %d", want, have)
+	}
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -26,10 +26,24 @@ func TestAppendPriority(t *testing.T) {
 	q := NewQueue()
 
 	q.AppendPriority("value1", PriorityLow)
-	q.AppendPriority("value2", PriorityHigh)
+	q.AppendPriority("value2", PriorityNormal)
+	q.AppendPriority("value3", PriorityHigh)
+	q.AppendPriority("value4", PriorityCritical)
+	q.AppendPriority("value5", PriorityLow)
+	q.AppendPriority("value6", PriorityNormal)
+	q.AppendPriority("value7", PriorityHigh)
+	q.AppendPriority("value8", PriorityCritical)
 
-	if e, _ := q.Next(); e != "value2" {
-		t.Errorf("The lower priority element was returned instead")
+	expected := []string{
+		"value4", "value8",
+		"value3", "value7",
+		"value2", "value6",
+		"value1", "value5",
+	}
+	for _, want := range expected {
+		if have, _ := q.Next(); want != have {
+			t.Errorf("Element popped out of priority order, expected '%s' but got '%s'", want, have)
+		}
 	}
 }
 


### PR DESCRIPTION
The call to `sort.Sort` in `priorityQueue.Push` is unnecessary and imposes a significant CPU performance penalty on code which uses queues extensively, like Amass.

I added benchmarks to prove the significance of this claim. Removing the call to `sort.Sort` appears to reduce the cost of an append by around 3 orders of magnitude (from hundreds of microseconds to hundreds of nanoseconds), with no impact to functionality (ordering is already maintained by `heap.Push`)

With `sort.Sort` in place (93e6bbd9d321dbdd5fba36040a6fec3ea3d3f30c):
```
% go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/caffix/queue
BenchmarkAppend-16            	   10000	    491677 ns/op
BenchmarkAppendPriority-16    	   10000	    507887 ns/op
PASS
ok  	github.com/caffix/queue	10.189s
```

After removing it:
```
% go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/caffix/queue
BenchmarkAppend-16            	 6089890	       197 ns/op
BenchmarkAppendPriority-16    	 5634872	       225 ns/op
PASS
ok  	github.com/caffix/queue	3.545s
```